### PR TITLE
Implement search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Run the script from the command line with
 ./get_ssld_videos.py {search word(s)}
 ```
 
-to search for the word in the SSLD and download hits. The amount of search hits to download can be configured with `-n` or `--num-hits`:
+to search for the word in the SSLD and download hits.
+
+The amount of search hits to download can be configured with `-n` or `--num-hits`:
 ```
 ./get_ssld_videos.py -n 4 anka räv
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ or use the flag `--short-names` (`-S`) to rename to downloaded file to only ID n
 ```
 ./get_ssld_videos.py {signID} --short
 ```
-NB: `-S` works as a shorthand for `--short`.
+NB: `-S` works as a shorthand for `--short-names`.
 
 SignIDs can be given in the full five-digit format (e.g., `00001`) or without zero-fillers (e.g., `1`).
 Multiple signIDs can be entered at once, and both input formats can be mixed:

--- a/README.md
+++ b/README.md
@@ -5,19 +5,23 @@ Requires Python3 with package `bs4`.
 
 Run the script from the command line with
 ```
-./get_ssld_videos.py {signID}
+./get_ssld_videos.py {search word(s)}
 ```
-or use the flag `--short-names` (`-S`) to rename to downloaded file to only ID number plus file extension (e.g., `00001.mp4`).
-```
-./get_ssld_videos.py {signID} --short
-```
-NB: `-S` works as a shorthand for `--short-names`.
 
-SignIDs can be given in the full five-digit format (e.g., `00001`) or without zero-fillers (e.g., `1`).
-Multiple signIDs can be entered at once, and both input formats can be mixed:
+to search for the word in the SSLD and download hits. The amount of search hits to download can be configured with `-n` or `--num-hits`:
 ```
-./get_ssld_videos.py 00001 2 00003
+./get_ssld_videos.py -n 4 anka räv
+```
+
+Downloading one or more IDs from the SSLD can be done with the `-i` or `--ids` flag:
+```
+./get_ssld_videos.py -i 548 9943
+```
+
+Using the flag `-S` or `--short-names` will save the files using only the ID and file extension (e.g., 00001.mp4).
+```
+./get_ssld_videos.py -S Australien
 ```
 
 ## TODO
-- [ ] Implement searching for names of signs instead of having to provide ID
+- [x] Implement searching for names of signs instead of having to provide ID

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ The amount of search hits to download can be configured with `-n` or `--num-hits
 ./get_ssld_videos.py -n 4 anka räv
 ```
 
+Searching for terms with spaces in them can be done by escaping the term in the shell:
+```
+./get_ssld_videos.py "dålig andedräkt" 10\ öre
+```
+
 Downloading one or more IDs from the SSLD can be done with the `-i` or `--ids` flag:
 ```
 ./get_ssld_videos.py -i 548 9943

--- a/get_ssld_videos.py
+++ b/get_ssld_videos.py
@@ -68,7 +68,7 @@ def main():
     parser.add_argument('-n', '--num-hits', dest='num_hits', default=2, type=int,
                         help='Max number of hits a search may yield.')
     # Take one or more ids to fetch.
-    parser.add_argument('-i', '--ids', dest='ids', type=int, nargs='*', help='ID(s) to download.')
+    parser.add_argument('-i', '--ids', dest='ids', nargs='*', help='ID(s) to download.')
     # Take one or more search words to fetch.
     parser.add_argument('searchwords', nargs='*', type=str, help='Word(s) to search for and download.')
     # Parse arguments

--- a/get_ssld_videos.py
+++ b/get_ssld_videos.py
@@ -61,11 +61,16 @@ def get_ids_from_name(name, maxfinds):
 def main():
     # Set up argument parser
     parser = argparse.ArgumentParser(description='Download videos from SSLD.')
-    # Take one or more ids to fetch.
-    parser.add_argument('ids', nargs='+', help='ID(s) to download.')
     # Provides the option -S to save using short (ID only) names.
     parser.add_argument('-S', '--short-names', dest='long_name', action='store_false',
                         help='Store using id-only (00001.mp4) names?')
+    # Provides the option -n to cap how many hits a search may yield.
+    parser.add_argument('-n', '--num-hits', dest='num_hits', default=2, type=int,
+                        help='Max number of hits a search may yield.')
+    # Take one or more ids to fetch.
+    parser.add_argument('-i', '--ids', dest='ids', type=int, nargs='*', help='ID(s) to download.')
+    # Take one or more search words to fetch.
+    parser.add_argument('searchwords', nargs='*', type=str, help='Word(s) to search for and download.')
     # Parse arguments
     args = parser.parse_args()
     get_videos(args.ids, args.long_name)

--- a/get_ssld_videos.py
+++ b/get_ssld_videos.py
@@ -82,6 +82,9 @@ def main():
     if args.searchwords is not None:
         for word in args.searchwords:
             word_ids = get_ids_from_name(word, args.num_hits)
+            if len(word_ids) == 0:
+                print("Unable to find any signs for word {}.".format(word))
+                continue
             for id in word_ids:
                 ids.append(id)
 

--- a/get_ssld_videos.py
+++ b/get_ssld_videos.py
@@ -73,7 +73,25 @@ def main():
     parser.add_argument('searchwords', nargs='*', type=str, help='Word(s) to search for and download.')
     # Parse arguments
     args = parser.parse_args()
-    get_videos(args.ids, args.long_name)
+
+    if args.num_hits is not None and args.searchwords is None:
+        print("--num-hits only relevant when used with searchwords.")
+
+    ids = []
+    # Add searchwords to list of IDs to fetch
+    if args.searchwords is not None:
+        for word in args.searchwords:
+            word_ids = get_ids_from_name(word, args.num_hits)
+            for id in word_ids:
+                ids.append(id)
+
+    # Add ids to list of IDs to fetch
+    if args.ids is not None:
+        for id in args.ids:
+            ids.append(id)
+
+    # Fetch IDs
+    get_videos(ids, args.long_name)
 
 if __name__ == "__main__":
     main()

--- a/get_ssld_videos.py
+++ b/get_ssld_videos.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 import urllib
 from urllib import request
+from urllib import parse
 from bs4 import BeautifulSoup
 
 """
@@ -38,6 +39,24 @@ def get_videos(ids, long_name):
         if len(id) < 5:
             id = id.zfill(5)
         fetch_sign_video(id, long_name)
+
+
+def get_ids_from_name(name, maxfinds):
+    """Returns a list of IDs that match the search term 'name'. """
+    base = "https://teckensprakslexikon.su.se/sok?{}"
+    q = {"q": name}
+    try:
+        query = base.format(urllib.parse.urlencode(q))
+        page = urllib.request.urlopen(query)
+        soup = BeautifulSoup(page, 'html.parser')
+        tb = soup.find('tbody')
+        ids = tb.find_all("td", class_='id')
+        spantexts = [i.find('span').text for i in ids]
+        if len(ids) > maxfinds:
+            return spantexts[:maxfinds]
+        return spantexts
+    except Exception as e:
+        sys.exit(e)
 
 def main():
     # Set up argument parser


### PR DESCRIPTION
Hi!

This pull request implements search as a feature. It does change the default behaviour, as in, the bare arguments are now treated as search terms. The ability to download IDs directly is preserved through the `-i`/`--ids` flag. See README.md diff for documentation regarding this behaviour. 
Feel free to reject this pull request should you deem breaking backwards compatibility unsatisfactory and we can change the default behaviour to treat bare arguments as IDs, and have searching be an optional flag.

The searching is done similarly to downloading bare IDs, as in, parsing HTML from a page. This is done without pulling in more dependencies as bs4 and urllib can do this just fine. An option to determine how many search results to download is available through the `-n`/`--num-hits` flag, and it defaults to 2. The search provides a list of max `-n` IDs that matched the query, and feeds them into the downloading function. Searching for terms that contain spaces can be done if you escape them properly in the shell. So one'd provide `"förstår inte"` or possibly `förstår\ inte` as a search term.